### PR TITLE
Update Transparent Proxy to 1.9.2

### DIFF
--- a/operator.yaml
+++ b/operator.yaml
@@ -1184,3 +1184,4 @@ spec:
       - configMap:
           name: sap-transp-proxy-sap-transp-proxy-operator-logging-config
         name: sap-transp-proxy-operator-logging-config
+---


### PR DESCRIPTION
This PR updates the Transparent Proxy operator manifest to version 1.9.2.

**Changes:**
- Updated operator.yaml with latest manifest

**Version:** 1.9.2