### PR TITLE
Update Transparent Proxy to 1.9.5

### DIFF
--- a/operator.yaml
+++ b/operator.yaml
@@ -1123,7 +1123,7 @@ spec:
         env:
         - name: GODEBUG
           value: fips140=on
-        image: sapse/sap-transp-proxy-operator:1.9.4
+        image: sapse/sap-transp-proxy-operator:1.9.5
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This PR updates the Transparent Proxy operator manifest to version 1.9.5.

**Changes:**
- Updated operator.yaml with latest manifest

**Version:** 1.9.5