### PR TITLE
Update Transparent Proxy to 1.9.9

### DIFF
--- a/operator.yaml
+++ b/operator.yaml
@@ -1220,7 +1220,7 @@ spec:
         env:
         - name: GODEBUG
           value: fips140=on
-        image: sapse/sap-transp-proxy-operator:1.9.8
+        image: sapse/sap-transp-proxy-operator:1.9.9
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This PR updates the Transparent Proxy operator manifest to version 1.9.9.

**Changes:**
- Updated operator.yaml with latest manifest

**Version:** 1.9.9